### PR TITLE
名前空間をDrecom以下に移動

### DIFF
--- a/CSharp/Clipper2Lib.Benchmark/Benchmarks.cs
+++ b/CSharp/Clipper2Lib.Benchmark/Benchmarks.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 
-namespace Clipper2Lib.Benchmark
+namespace Drecom.Clipper2Lib.Benchmark
 {
   public class FastConfig : ManualConfig
     {

--- a/CSharp/Clipper2Lib.Benchmark/Program.cs
+++ b/CSharp/Clipper2Lib.Benchmark/Program.cs
@@ -1,6 +1,6 @@
 using BenchmarkDotNet.Running;
 
-namespace Clipper2Lib.Benchmark
+namespace Drecom.Clipper2Lib.Benchmark
 {
     public class Program
     {        

--- a/CSharp/Clipper2Lib.Examples/ConsoleDemo/Main.cs
+++ b/CSharp/Clipper2Lib.Examples/ConsoleDemo/Main.cs
@@ -9,7 +9,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
-using Clipper2Lib;
+using Drecom.Clipper2Lib;
 
 namespace ClipperDemo1
 {

--- a/CSharp/Clipper2Lib.Examples/InflateDemo/Main.cs
+++ b/CSharp/Clipper2Lib.Examples/InflateDemo/Main.cs
@@ -9,7 +9,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using Clipper2Lib;
+using Drecom.Clipper2Lib;
 
 namespace ClipperDemo1
 {

--- a/CSharp/Clipper2Lib.Tests/Tests1/Tests/TestPolygons.cs
+++ b/CSharp/Clipper2Lib.Tests/Tests1/Tests/TestPolygons.cs
@@ -1,6 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Clipper2Lib.UnitTests
+namespace Drecom.Clipper2Lib.UnitTests
 {
 
   [TestClass]

--- a/CSharp/Clipper2Lib/Clipper.Core.cs
+++ b/CSharp/Clipper2Lib/Clipper.Core.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
   public struct Point64
   {

--- a/CSharp/Clipper2Lib/Clipper.Engine.cs
+++ b/CSharp/Clipper2Lib/Clipper.Engine.cs
@@ -16,7 +16,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
 
   // Vertex: a pre-clipping data structure. It is used to separate polygons

--- a/CSharp/Clipper2Lib/Clipper.Minkowski.cs
+++ b/CSharp/Clipper2Lib/Clipper.Minkowski.cs
@@ -11,7 +11,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
   public class Minkowski
   {

--- a/CSharp/Clipper2Lib/Clipper.Offset.cs
+++ b/CSharp/Clipper2Lib/Clipper.Offset.cs
@@ -11,7 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
   public enum JoinType
   {

--- a/CSharp/Clipper2Lib/Clipper.RectClip.cs
+++ b/CSharp/Clipper2Lib/Clipper.RectClip.cs
@@ -14,7 +14,7 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
     public class RectClip
   {

--- a/CSharp/Clipper2Lib/Clipper.cs
+++ b/CSharp/Clipper2Lib/Clipper.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
 
   // PRE-COMPILER CONDITIONAL ...

--- a/CSharp/Utils/ClipFileIO/Clipper.FileIO.cs
+++ b/CSharp/Utils/ClipFileIO/Clipper.FileIO.cs
@@ -10,7 +10,7 @@ using System;
 using System.IO;
 using System.Diagnostics;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
 
   public static class ClipperFileIO

--- a/CSharp/Utils/SVG/Clipper.SVG.Utils.cs
+++ b/CSharp/Utils/SVG/Clipper.SVG.Utils.cs
@@ -8,7 +8,7 @@
 
 using System.IO;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
 
   public static class SvgUtils

--- a/CSharp/Utils/SVG/Clipper.SVG.cs
+++ b/CSharp/Utils/SVG/Clipper.SVG.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
-namespace Clipper2Lib
+namespace Drecom.Clipper2Lib
 {
   public class SimpleSvgWriter
   {


### PR DESCRIPTION
## 概要
将来的な競合に備え、namespaceを`Drecom`の子階層に移動させる

## 変更
+ `CSharp/` 以下のnamespaceを`Drecom`の子階層に移動