### PR TITLE
C# ビルドのCI調整

### DIFF
--- a/.github/workflows/actions_cpp.yml
+++ b/.github/workflows/actions_cpp.yml
@@ -1,7 +1,8 @@
 name: C++
 on:
-  push:
   pull_request:
+    branches-ignore: # Disable C++ build
+      - '**'
 jobs:
   windows-latest:
     runs-on: 'windows-latest'

--- a/.github/workflows/actions_csharp.yml
+++ b/.github/workflows/actions_csharp.yml
@@ -20,6 +20,8 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.x
+      - name: Restore
+        run: dotnet restore
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Test

--- a/.github/workflows/actions_csharp.yml
+++ b/.github/workflows/actions_csharp.yml
@@ -1,24 +1,26 @@
 name: C#
 on:
   push:
+    branches: ["main", "drecom/develop"]
   pull_request:
+    branches: ["main", "drecom/develop"]
 jobs:
-  windows-latest:
-    runs-on: 'windows-latest'
+  build:
+    runs-on: "ubuntu-latest"
     defaults:
       run:
         working-directory: ./CSharp
     steps:
-    - uses: actions/checkout@v2
-    - name: Copy Clipper2Lib to USINGZ directory
-      run: cp Clipper2Lib/*.cs USINGZ/
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with: 
-        dotnet-version: '5.0.x'    
-    - name: Install Dependencies
-      run: dotnet restore
-    - name: Build Solution
-      run: dotnet build --configuration Release --no-restore
-    - name: Run Tests
-      run: dotnet test --no-restore --verbosity normal
+      - uses: actions/checkout@v3
+      - name: Copy Clipper2Lib to USINGZ directory
+        run: cp Clipper2Lib/*.cs USINGZ/
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            3.1.x
+            6.0.x
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/CSharp/Clipper2Lib.Benchmark/Clipper2Lib.Benchmark.csproj
+++ b/CSharp/Clipper2Lib.Benchmark/Clipper2Lib.Benchmark.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/CSharp/Clipper2Lib.Examples/ConsoleDemo/ConsoleDemo.csproj
+++ b/CSharp/Clipper2Lib.Examples/ConsoleDemo/ConsoleDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <ApplicationIcon>Clipper2.ico</ApplicationIcon>
   </PropertyGroup>

--- a/CSharp/Clipper2Lib.Examples/InflateDemo/InflateDemo.csproj
+++ b/CSharp/Clipper2Lib.Examples/InflateDemo/InflateDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <ApplicationIcon>Clipper2.ico</ApplicationIcon>
   </PropertyGroup>

--- a/CSharp/Clipper2Lib.Examples/RectClip/RectClipDemo.csproj
+++ b/CSharp/Clipper2Lib.Examples/RectClip/RectClipDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <ApplicationIcon>Clipper2.ico</ApplicationIcon>
     <Platforms>AnyCPU;x86</Platforms>

--- a/CSharp/USINGZ/Clipper2LibZ.csproj
+++ b/CSharp/USINGZ/Clipper2LibZ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/CSharp/Utils/ClipFileIO/Clipper.FileIO.csproj
+++ b/CSharp/Utils/ClipFileIO/Clipper.FileIO.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharp/Utils/SVG/Clipper2.SVG.csproj
+++ b/CSharp/Utils/SVG/Clipper2.SVG.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 概要
.NET 3.1.x, 6.xのビルドを行うプロジェクトとgithub actionをセットアップする

## 変更
+ C++ビルドを無効化
+ csprojの実行可能プロジェクトの`TargetFramework`を `net5.0` -> `net6.0`に
+ actionsのビルド対象を調整